### PR TITLE
Use PSRAM if available

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "ESPMicroSpeechFeatures",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Generates TensorFlow micro spectrogram features from audio samples",
     "keywords": "tensorflow, spectrogram, audio",
     "repository":

--- a/src/fft_util.c
+++ b/src/fft_util.c
@@ -17,24 +17,40 @@ limitations under the License.
 
 #include <stdio.h>
 
+#ifdef USE_ESP32
+#include <esp_heap_caps.h>
+#endif
+
 #include "kiss_fftr.h"
 
-int FftPopulateState(struct FftState *state, size_t input_size) {
+int FftPopulateState(struct FftState *state, size_t input_size)
+{
   state->input_size = input_size;
   state->fft_size = 1;
-  while (state->fft_size < state->input_size) {
+  while (state->fft_size < state->input_size)
+  {
     state->fft_size <<= 1;
   }
 
-  state->input = (int16_t *) (malloc(state->fft_size * sizeof(*state->input)));
-  if (state->input == NULL) {
+#ifdef USE_ESP32
+  state->input = (int16_t *)(heap_caps_malloc(state->fft_size * sizeof(*state->input), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+#else
+  state->input = (int16_t *)(malloc(state->fft_size * sizeof(*state->input)));
+#endif
+  if (state->input == NULL)
+  {
     fprintf(stderr, "Failed to alloc fft input buffer\n");
     return 0;
   }
 
   // Cast to int32_t instead of the original complex_int16_t, easy way to fix issues converting the original file into C (may not be the best/proper way!)
-  state->output = (int32_t *) (malloc((state->fft_size / 2 + 1) * sizeof(*state->output) * 2));
-  if (state->output == NULL) {
+#ifdef USE_ESP32
+  state->output = (int32_t *)(heap_caps_malloc((state->fft_size / 2 + 1) * sizeof(*state->output) * 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+#else
+  state->output = (int32_t *)(malloc((state->fft_size / 2 + 1) * sizeof(*state->output) * 2));
+#endif
+  if (state->output == NULL)
+  {
     fprintf(stderr, "Failed to alloc fft output buffer\n");
     return 0;
   }
@@ -42,26 +58,35 @@ int FftPopulateState(struct FftState *state, size_t input_size) {
   // Ask kissfft how much memory it wants.
   size_t scratch_size = 0;
   kiss_fftr_cfg kfft_cfg = kiss_fftr_alloc(state->fft_size, 0, NULL, &scratch_size);
-  if (kfft_cfg != NULL) {
+  if (kfft_cfg != NULL)
+  {
     fprintf(stderr, "Kiss memory sizing failed.\n");
     return 0;
   }
+
+#ifdef USE_ESP32
+  state->scratch = heap_caps_malloc(scratch_size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+#else
   state->scratch = malloc(scratch_size);
-  if (state->scratch == NULL) {
+#endif
+  if (state->scratch == NULL)
+  {
     fprintf(stderr, "Failed to alloc fft scratch buffer\n");
     return 0;
   }
   state->scratch_size = scratch_size;
   // Let kissfft configure the scratch space we just allocated
   kfft_cfg = kiss_fftr_alloc(state->fft_size, 0, state->scratch, &scratch_size);
-  if (kfft_cfg != state->scratch) {
+  if (kfft_cfg != state->scratch)
+  {
     fprintf(stderr, "Kiss memory preallocation strategy failed.\n");
     return 0;
   }
   return 1;
 }
 
-void FftFreeStateContents(struct FftState *state) {
+void FftFreeStateContents(struct FftState *state)
+{
   free(state->input);
   free(state->output);
   free(state->scratch);

--- a/src/fft_util.c
+++ b/src/fft_util.c
@@ -33,7 +33,8 @@ int FftPopulateState(struct FftState *state, size_t input_size)
   }
 
 #ifdef USE_ESP32
-  state->input = (int16_t *)(heap_caps_malloc(state->fft_size * sizeof(*state->input), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  state->input =
+      (int16_t *)(heap_caps_malloc(state->fft_size * sizeof(*state->input), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
 #else
   state->input = (int16_t *)(malloc(state->fft_size * sizeof(*state->input)));
 #endif
@@ -43,11 +44,11 @@ int FftPopulateState(struct FftState *state, size_t input_size)
     return 0;
   }
 
-  // Cast to int32_t instead of the original complex_int16_t, easy way to fix issues converting the original file into C (may not be the best/proper way!)
 #ifdef USE_ESP32
-  state->output = (int32_t *)(heap_caps_malloc((state->fft_size / 2 + 1) * sizeof(*state->output) * 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  state->output = heap_caps_malloc((state->fft_size / 2 + 1) * sizeof(*state->output) * 2,
+                                   MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
 #else
-  state->output = (int32_t *)(malloc((state->fft_size / 2 + 1) * sizeof(*state->output) * 2));
+  state->output = malloc((state->fft_size / 2 + 1) * sizeof(*state->output) * 2);
 #endif
   if (state->output == NULL)
   {

--- a/src/fft_util.c
+++ b/src/fft_util.c
@@ -34,10 +34,12 @@ int FftPopulateState(struct FftState *state, size_t input_size)
 
 #ifdef USE_ESP32
   state->input =
-      (int16_t *)(heap_caps_malloc(state->fft_size * sizeof(*state->input), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
-#else
-  state->input = (int16_t *)(malloc(state->fft_size * sizeof(*state->input)));
+      heap_caps_malloc(state->fft_size * sizeof(*state->input), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (state->input == NULL)
 #endif
+  {
+    state->input = malloc(state->fft_size * sizeof(*state->input));
+  }
   if (state->input == NULL)
   {
     fprintf(stderr, "Failed to alloc fft input buffer\n");
@@ -47,9 +49,11 @@ int FftPopulateState(struct FftState *state, size_t input_size)
 #ifdef USE_ESP32
   state->output = heap_caps_malloc((state->fft_size / 2 + 1) * sizeof(*state->output) * 2,
                                    MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-#else
-  state->output = malloc((state->fft_size / 2 + 1) * sizeof(*state->output) * 2);
+  if (state->output == NULL)
 #endif
+  {
+    state->output = malloc((state->fft_size / 2 + 1) * sizeof(*state->output) * 2);
+  }
   if (state->output == NULL)
   {
     fprintf(stderr, "Failed to alloc fft output buffer\n");
@@ -67,9 +71,12 @@ int FftPopulateState(struct FftState *state, size_t input_size)
 
 #ifdef USE_ESP32
   state->scratch = heap_caps_malloc(scratch_size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-#else
-  state->scratch = malloc(scratch_size);
+  if (state->scratch == NULL)
 #endif
+  {
+    state->scratch = malloc(scratch_size);
+  }
+
   if (state->scratch == NULL)
   {
     fprintf(stderr, "Failed to alloc fft scratch buffer\n");

--- a/src/filterbank_util.c
+++ b/src/filterbank_util.c
@@ -1,4 +1,5 @@
 /* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+Modifications copyright 2024 Kevin Ahrendt.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,10 +19,15 @@ limitations under the License.
 #include <math.h>
 #include <stdio.h>
 
+#ifdef USE_ESP32
+#include <esp_heap_caps.h>
+#endif
+
 #define kFilterbankIndexAlignment 4
 #define kFilterbankChannelBlockSize 4
 
-void FilterbankFillConfigWithDefaults(struct FilterbankConfig *config) {
+void FilterbankFillConfigWithDefaults(struct FilterbankConfig *config)
+{
   config->num_channels = 32;
   config->lower_band_limit = 125.0f;
   config->upper_band_limit = 7500.0f;
@@ -31,27 +37,31 @@ void FilterbankFillConfigWithDefaults(struct FilterbankConfig *config) {
 static float FreqToMel(float freq) { return 1127.0f * log1pf(freq / 700.0f); }
 
 static void CalculateCenterFrequencies(const int num_channels, const float lower_frequency_limit,
-                                       const float upper_frequency_limit, float *center_frequencies) {
+                                       const float upper_frequency_limit, float *center_frequencies)
+{
   assert(lower_frequency_limit >= 0.0f);
   assert(upper_frequency_limit > lower_frequency_limit);
 
   const float mel_low = FreqToMel(lower_frequency_limit);
   const float mel_hi = FreqToMel(upper_frequency_limit);
   const float mel_span = mel_hi - mel_low;
-  const float mel_spacing = mel_span / ((float) num_channels);
+  const float mel_spacing = mel_span / ((float)num_channels);
   int i;
-  for (i = 0; i < num_channels; ++i) {
+  for (i = 0; i < num_channels; ++i)
+  {
     center_frequencies[i] = mel_low + (mel_spacing * (i + 1));
   }
 }
 
-static void QuantizeFilterbankWeights(const float float_weight, int16_t *weight, int16_t *unweight) {
+static void QuantizeFilterbankWeights(const float float_weight, int16_t *weight, int16_t *unweight)
+{
   *weight = floorf(float_weight * (1 << kFilterbankBits) + 0.5f);
   *unweight = floorf((1.0f - float_weight) * (1 << kFilterbankBits) + 0.5f);
 }
 
 int FilterbankPopulateState(const struct FilterbankConfig *config, struct FilterbankState *state, int sample_rate,
-                            int spectrum_size) {
+                            int spectrum_size)
+{
   state->num_channels = config->num_channels;
   const int num_channels_plus_1 = config->num_channels + 1;
 
@@ -59,18 +69,29 @@ int FilterbankPopulateState(const struct FilterbankConfig *config, struct Filter
   const int index_alignment =
       (kFilterbankIndexAlignment < sizeof(int16_t) ? 1 : kFilterbankIndexAlignment / sizeof(int16_t));
 
-  state->channel_frequency_starts = (int16_t *) malloc(num_channels_plus_1 * sizeof(*state->channel_frequency_starts));
-  state->channel_weight_starts = (int16_t *) malloc(num_channels_plus_1 * sizeof(*state->channel_weight_starts));
-  state->channel_widths = (int16_t *) malloc(num_channels_plus_1 * sizeof(*state->channel_widths));
-  state->work = (uint64_t *) malloc(num_channels_plus_1 * sizeof(*state->work));
+#ifdef USE_ESP32
+  state->channel_frequency_starts = (int16_t *)heap_caps_malloc(num_channels_plus_1 * sizeof(*state->channel_frequency_starts), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  state->channel_weight_starts = (int16_t *)heap_caps_malloc(num_channels_plus_1 * sizeof(*state->channel_weight_starts), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  state->channel_widths = (int16_t *)heap_caps_malloc(num_channels_plus_1 * sizeof(*state->channel_widths), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  state->work = (uint64_t *)heap_caps_malloc(num_channels_plus_1 * sizeof(*state->work), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
 
-  float *center_mel_freqs = (float *) malloc(num_channels_plus_1 * sizeof(*center_mel_freqs));
-  int16_t *actual_channel_starts = (int16_t *) malloc(num_channels_plus_1 * sizeof(*actual_channel_starts));
-  int16_t *actual_channel_widths = (int16_t *) malloc(num_channels_plus_1 * sizeof(*actual_channel_widths));
+  float *center_mel_freqs = (float *)heap_caps_malloc(num_channels_plus_1 * sizeof(*center_mel_freqs), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  int16_t *actual_channel_starts = (int16_t *)heap_caps_malloc(num_channels_plus_1 * sizeof(*actual_channel_starts), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  int16_t *actual_channel_widths = (int16_t *)heap_caps_malloc(num_channels_plus_1 * sizeof(*actual_channel_widths), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+#else
+  state->channel_frequency_starts = (int16_t *)malloc(num_channels_plus_1 * sizeof(*state->channel_frequency_starts));
+  state->channel_weight_starts = (int16_t *)malloc(num_channels_plus_1 * sizeof(*state->channel_weight_starts));
+  state->channel_widths = (int16_t *)malloc(num_channels_plus_1 * sizeof(*state->channel_widths));
+  state->work = (uint64_t *)malloc(num_channels_plus_1 * sizeof(*state->work));
 
+  float *center_mel_freqs = (float *)malloc(num_channels_plus_1 * sizeof(*center_mel_freqs));
+  int16_t *actual_channel_starts = (int16_t *)malloc(num_channels_plus_1 * sizeof(*actual_channel_starts));
+  int16_t *actual_channel_widths = (int16_t *)malloc(num_channels_plus_1 * sizeof(*actual_channel_widths));
+#endif
   if (state->channel_frequency_starts == NULL || state->channel_weight_starts == NULL ||
       state->channel_widths == NULL || center_mel_freqs == NULL || actual_channel_starts == NULL ||
-      actual_channel_widths == NULL) {
+      actual_channel_widths == NULL)
+  {
     free(center_mel_freqs);
     free(actual_channel_starts);
     free(actual_channel_widths);
@@ -81,9 +102,9 @@ int FilterbankPopulateState(const struct FilterbankConfig *config, struct Filter
   CalculateCenterFrequencies(num_channels_plus_1, config->lower_band_limit, config->upper_band_limit, center_mel_freqs);
 
   // Always exclude DC.
-  const float hz_per_sbin = 0.5f * sample_rate / ((float) spectrum_size - 1);
+  const float hz_per_sbin = 0.5f * sample_rate / ((float)spectrum_size - 1);
   state->start_index = 1.5f + config->lower_band_limit / hz_per_sbin;
-  state->end_index = 0;  // Initialized to zero here, but actually set below.
+  state->end_index = 0; // Initialized to zero here, but actually set below.
 
   // For each channel, we need to figure out what frequencies belong to it, and
   // how much padding we need to add so that we can efficiently multiply the
@@ -96,10 +117,12 @@ int FilterbankPopulateState(const struct FilterbankConfig *config, struct Filter
   int needs_zeros = 0;
 
   int chan;
-  for (chan = 0; chan < num_channels_plus_1; ++chan) {
+  for (chan = 0; chan < num_channels_plus_1; ++chan)
+  {
     // Keep jumping frequencies until we overshoot the bound on this channel.
     int freq_index = chan_freq_index_start;
-    while (FreqToMel((freq_index) *hz_per_sbin) <= center_mel_freqs[chan]) {
+    while (FreqToMel((freq_index)*hz_per_sbin) <= center_mel_freqs[chan])
+    {
       ++freq_index;
     }
 
@@ -107,7 +130,8 @@ int FilterbankPopulateState(const struct FilterbankConfig *config, struct Filter
     actual_channel_starts[chan] = chan_freq_index_start;
     actual_channel_widths[chan] = width;
 
-    if (width == 0) {
+    if (width == 0)
+    {
       // This channel doesn't actually get anything from the frequencies, it's
       // always zero. We need then to insert some 'zero' weights into the
       // output, and just redirect this channel to do a single multiplication at
@@ -117,15 +141,19 @@ int FilterbankPopulateState(const struct FilterbankConfig *config, struct Filter
       state->channel_frequency_starts[chan] = 0;
       state->channel_weight_starts[chan] = 0;
       state->channel_widths[chan] = kFilterbankChannelBlockSize;
-      if (!needs_zeros) {
+      if (!needs_zeros)
+      {
         needs_zeros = 1;
         int j;
-        for (j = 0; j < chan; ++j) {
+        for (j = 0; j < chan; ++j)
+        {
           state->channel_weight_starts[j] += kFilterbankChannelBlockSize;
         }
         weight_index_start += kFilterbankChannelBlockSize;
       }
-    } else {
+    }
+    else
+    {
       // How far back do we need to go to ensure that we have the proper
       // alignment?
       const int aligned_start = (chan_freq_index_start / index_alignment) * index_alignment;
@@ -143,11 +171,12 @@ int FilterbankPopulateState(const struct FilterbankConfig *config, struct Filter
   // Allocate the two arrays to store the weights - weight_index_start contains
   // the index of what would be the next set of weights that we would need to
   // add, so that's how many weights we need to allocate.
-  state->weights = (int16_t *) calloc(weight_index_start, sizeof(*state->weights));
-  state->unweights = (int16_t *) calloc(weight_index_start, sizeof(*state->unweights));
+  state->weights = (int16_t *)calloc(weight_index_start, sizeof(*state->weights));
+  state->unweights = (int16_t *)calloc(weight_index_start, sizeof(*state->unweights));
 
   // If the alloc failed, we also need to nuke the arrays.
-  if (state->weights == NULL || state->unweights == NULL) {
+  if (state->weights == NULL || state->unweights == NULL)
+  {
     free(center_mel_freqs);
     free(actual_channel_starts);
     free(actual_channel_widths);
@@ -159,7 +188,8 @@ int FilterbankPopulateState(const struct FilterbankConfig *config, struct Filter
   // zero, we only need to fill in the weights that correspond to some frequency
   // for a channel.
   const float mel_low = FreqToMel(config->lower_band_limit);
-  for (chan = 0; chan < num_channels_plus_1; ++chan) {
+  for (chan = 0; chan < num_channels_plus_1; ++chan)
+  {
     int frequency = actual_channel_starts[chan];
     const int num_frequencies = actual_channel_widths[chan];
     const int frequency_offset = frequency - state->channel_frequency_starts[chan];
@@ -167,7 +197,8 @@ int FilterbankPopulateState(const struct FilterbankConfig *config, struct Filter
     const float denom_val = (chan == 0) ? mel_low : center_mel_freqs[chan - 1];
 
     int j;
-    for (j = 0; j < num_frequencies; ++j, ++frequency) {
+    for (j = 0; j < num_frequencies; ++j, ++frequency)
+    {
       const float weight =
           (center_mel_freqs[chan] - FreqToMel(frequency * hz_per_sbin)) / (center_mel_freqs[chan] - denom_val);
 
@@ -175,7 +206,8 @@ int FilterbankPopulateState(const struct FilterbankConfig *config, struct Filter
       const int weight_index = weight_start + frequency_offset + j;
       QuantizeFilterbankWeights(weight, state->weights + weight_index, state->unweights + weight_index);
     }
-    if (frequency > state->end_index) {
+    if (frequency > state->end_index)
+    {
       state->end_index = frequency;
     }
   }
@@ -183,14 +215,16 @@ int FilterbankPopulateState(const struct FilterbankConfig *config, struct Filter
   free(center_mel_freqs);
   free(actual_channel_starts);
   free(actual_channel_widths);
-  if (state->end_index >= spectrum_size) {
+  if (state->end_index >= spectrum_size)
+  {
     fprintf(stderr, "Filterbank end_index is above spectrum size.\n");
     return 0;
   }
   return 1;
 }
 
-void FilterbankFreeStateContents(struct FilterbankState *state) {
+void FilterbankFreeStateContents(struct FilterbankState *state)
+{
   free(state->channel_frequency_starts);
   free(state->channel_weight_starts);
   free(state->channel_widths);

--- a/src/filterbank_util.c
+++ b/src/filterbank_util.c
@@ -70,24 +70,64 @@ int FilterbankPopulateState(const struct FilterbankConfig *config, struct Filter
       (kFilterbankIndexAlignment < sizeof(int16_t) ? 1 : kFilterbankIndexAlignment / sizeof(int16_t));
 
 #ifdef USE_ESP32
-  state->channel_frequency_starts = (int16_t *)heap_caps_malloc(num_channels_plus_1 * sizeof(*state->channel_frequency_starts), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-  state->channel_weight_starts = (int16_t *)heap_caps_malloc(num_channels_plus_1 * sizeof(*state->channel_weight_starts), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-  state->channel_widths = (int16_t *)heap_caps_malloc(num_channels_plus_1 * sizeof(*state->channel_widths), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-  state->work = (uint64_t *)heap_caps_malloc(num_channels_plus_1 * sizeof(*state->work), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-
-  float *center_mel_freqs = (float *)heap_caps_malloc(num_channels_plus_1 * sizeof(*center_mel_freqs), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-  int16_t *actual_channel_starts = (int16_t *)heap_caps_malloc(num_channels_plus_1 * sizeof(*actual_channel_starts), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-  int16_t *actual_channel_widths = (int16_t *)heap_caps_malloc(num_channels_plus_1 * sizeof(*actual_channel_widths), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-#else
-  state->channel_frequency_starts = (int16_t *)malloc(num_channels_plus_1 * sizeof(*state->channel_frequency_starts));
-  state->channel_weight_starts = (int16_t *)malloc(num_channels_plus_1 * sizeof(*state->channel_weight_starts));
-  state->channel_widths = (int16_t *)malloc(num_channels_plus_1 * sizeof(*state->channel_widths));
-  state->work = (uint64_t *)malloc(num_channels_plus_1 * sizeof(*state->work));
-
-  float *center_mel_freqs = (float *)malloc(num_channels_plus_1 * sizeof(*center_mel_freqs));
-  int16_t *actual_channel_starts = (int16_t *)malloc(num_channels_plus_1 * sizeof(*actual_channel_starts));
-  int16_t *actual_channel_widths = (int16_t *)malloc(num_channels_plus_1 * sizeof(*actual_channel_widths));
+  state->channel_frequency_starts = heap_caps_malloc(num_channels_plus_1 * sizeof(*state->channel_frequency_starts), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (state->channel_frequency_starts == NULL)
 #endif
+  {
+    state->channel_frequency_starts = malloc(num_channels_plus_1 * sizeof(*state->channel_frequency_starts));
+  }
+
+#ifdef USE_ESP32
+  state->channel_weight_starts = heap_caps_malloc(num_channels_plus_1 * sizeof(*state->channel_weight_starts), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (state->channel_weight_starts == NULL)
+#endif
+  {
+    state->channel_weight_starts = malloc(num_channels_plus_1 * sizeof(*state->channel_weight_starts));
+  }
+
+#ifdef USE_ESP32
+  state->channel_widths = heap_caps_malloc(num_channels_plus_1 * sizeof(*state->channel_widths), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (state->channel_widths == NULL)
+#endif
+  {
+    state->channel_widths = malloc(num_channels_plus_1 * sizeof(*state->channel_widths));
+  }
+
+#ifdef USE_ESP32
+  state->work = heap_caps_malloc(num_channels_plus_1 * sizeof(*state->work), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (state->work == NULL)
+#endif
+  {
+    state->work = malloc(num_channels_plus_1 * sizeof(*state->work));
+  }
+
+  float *center_mel_freqs = NULL;
+#ifdef USE_ESP32
+  center_mel_freqs = heap_caps_malloc(num_channels_plus_1 * sizeof(*center_mel_freqs), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (center_mel_freqs == NULL)
+#endif
+  {
+    center_mel_freqs = malloc(num_channels_plus_1 * sizeof(*center_mel_freqs));
+  }
+
+  int16_t *actual_channel_starts = NULL;
+#ifdef USE_ESP32
+  actual_channel_starts = heap_caps_malloc(num_channels_plus_1 * sizeof(*actual_channel_starts), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (actual_channel_starts == NULL)
+#endif
+  {
+    actual_channel_starts = malloc(num_channels_plus_1 * sizeof(*actual_channel_starts));
+  }
+
+  int16_t *actual_channel_widths = NULL;
+#ifdef USE_ESP32
+  actual_channel_widths = heap_caps_malloc(num_channels_plus_1 * sizeof(*actual_channel_widths), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (actual_channel_widths == NULL)
+#endif
+  {
+    actual_channel_widths = malloc(num_channels_plus_1 * sizeof(*actual_channel_widths));
+  }
+
   if (state->channel_frequency_starts == NULL || state->channel_weight_starts == NULL ||
       state->channel_widths == NULL || center_mel_freqs == NULL || actual_channel_starts == NULL ||
       actual_channel_widths == NULL)

--- a/src/pcan_gain_control_util.c
+++ b/src/pcan_gain_control_util.c
@@ -57,10 +57,12 @@ int PcanGainControlPopulateState(const struct PcanGainControlConfig *config, str
   state->noise_estimate = noise_estimate;
   state->num_channels = num_channels;
 #ifdef USE_ESP32
-  state->gain_lut = (int16_t *)heap_caps_malloc(kWideDynamicFunctionLUTSize * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-#else
-  state->gain_lut = (int16_t *)malloc(kWideDynamicFunctionLUTSize * sizeof(int16_t));
+  state->gain_lut = heap_caps_malloc(kWideDynamicFunctionLUTSize * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (state->gain_lut == NULL)
 #endif
+  {
+    state->gain_lut = malloc(kWideDynamicFunctionLUTSize * sizeof(int16_t));
+  }
   if (state->gain_lut == NULL)
   {
     fprintf(stderr, "Failed to allocate gain LUT\n");

--- a/src/window_util.c
+++ b/src/window_util.c
@@ -1,4 +1,5 @@
 /* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+Modifications copyright 2024 Kevin Ahrendt.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,44 +20,66 @@ limitations under the License.
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef USE_ESP32
+#include <esp_heap_caps.h>
+#endif
+
 // Some platforms don't have M_PI
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #endif
 
-void WindowFillConfigWithDefaults(struct WindowConfig *config) {
+void WindowFillConfigWithDefaults(struct WindowConfig *config)
+{
   config->size_ms = 25;
   config->step_size_ms = 10;
 }
 
-int WindowPopulateState(const struct WindowConfig *config, struct WindowState *state, int sample_rate) {
+int WindowPopulateState(const struct WindowConfig *config, struct WindowState *state, int sample_rate)
+{
   state->size = config->size_ms * sample_rate / 1000;
   state->step = config->step_size_ms * sample_rate / 1000;
 
-  state->coefficients = (int16_t *) malloc(state->size * sizeof(*state->coefficients));
-  if (state->coefficients == NULL) {
+#ifdef USE_ESP32
+  state->coefficients = (int16_t *)heap_caps_malloc(state->size * sizeof(*state->coefficients), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+#else
+  state->coefficients = (int16_t *)malloc(state->size * sizeof(*state->coefficients));
+#endif
+  if (state->coefficients == NULL)
+  {
     fprintf(stderr, "Failed to allocate window coefficients\n");
     return 0;
   }
 
   // Populate the window values.
-  const float arg = (float) M_PI * 2.0f / ((float) state->size);
+  const float arg = (float)M_PI * 2.0f / ((float)state->size);
   size_t i;
-  for (i = 0; i < state->size; ++i) {
+  for (i = 0; i < state->size; ++i)
+  {
     float float_value = 0.5f - (0.5f * cosf(arg * (i + 0.5f)));
     // Scale it to fixed point and round it.
     state->coefficients[i] = floorf(float_value * (1 << kFrontendWindowBits) + 0.5f);
   }
 
   state->input_used = 0;
-  state->input = (int16_t *) malloc(state->size * sizeof(*state->input));
-  if (state->input == NULL) {
+#ifdef USE_ESP32
+  state->input = (int16_t *)heap_caps_malloc(state->size * sizeof(*state->input), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+#else
+  state->input = (int16_t *)malloc(state->size * sizeof(*state->input));
+#endif
+  if (state->input == NULL)
+  {
     fprintf(stderr, "Failed to allocate window input\n");
     return 0;
   }
 
-  state->output = (int16_t *) malloc(state->size * sizeof(*state->output));
-  if (state->output == NULL) {
+#ifdef USE_ESP32
+  state->output = (int16_t *)heap_caps_malloc(state->size * sizeof(*state->output), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+#else
+  state->output = (int16_t *)malloc(state->size * sizeof(*state->output));
+#endif
+  if (state->output == NULL)
+  {
     fprintf(stderr, "Failed to allocate window output\n");
     return 0;
   }
@@ -64,7 +87,8 @@ int WindowPopulateState(const struct WindowConfig *config, struct WindowState *s
   return 1;
 }
 
-void WindowFreeStateContents(struct WindowState *state) {
+void WindowFreeStateContents(struct WindowState *state)
+{
   free(state->coefficients);
   free(state->input);
   free(state->output);

--- a/src/window_util.c
+++ b/src/window_util.c
@@ -41,10 +41,12 @@ int WindowPopulateState(const struct WindowConfig *config, struct WindowState *s
   state->step = config->step_size_ms * sample_rate / 1000;
 
 #ifdef USE_ESP32
-  state->coefficients = (int16_t *)heap_caps_malloc(state->size * sizeof(*state->coefficients), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-#else
-  state->coefficients = (int16_t *)malloc(state->size * sizeof(*state->coefficients));
+  state->coefficients = heap_caps_malloc(state->size * sizeof(*state->coefficients), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (state->coefficients == NULL)
 #endif
+  {
+    state->coefficients = malloc(state->size * sizeof(*state->coefficients));
+  }
   if (state->coefficients == NULL)
   {
     fprintf(stderr, "Failed to allocate window coefficients\n");
@@ -63,10 +65,12 @@ int WindowPopulateState(const struct WindowConfig *config, struct WindowState *s
 
   state->input_used = 0;
 #ifdef USE_ESP32
-  state->input = (int16_t *)heap_caps_malloc(state->size * sizeof(*state->input), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-#else
-  state->input = (int16_t *)malloc(state->size * sizeof(*state->input));
+  state->input = heap_caps_malloc(state->size * sizeof(*state->input), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (state->input == NULL)
 #endif
+  {
+    state->input = malloc(state->size * sizeof(*state->input));
+  }
   if (state->input == NULL)
   {
     fprintf(stderr, "Failed to allocate window input\n");
@@ -74,10 +78,12 @@ int WindowPopulateState(const struct WindowConfig *config, struct WindowState *s
   }
 
 #ifdef USE_ESP32
-  state->output = (int16_t *)heap_caps_malloc(state->size * sizeof(*state->output), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-#else
-  state->output = (int16_t *)malloc(state->size * sizeof(*state->output));
+  state->output = heap_caps_malloc(state->size * sizeof(*state->output), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (state->output == NULL)
 #endif
+  {
+    state->output = malloc(state->size * sizeof(*state->output));
+  }
   if (state->output == NULL)
   {
     fprintf(stderr, "Failed to allocate window output\n");


### PR DESCRIPTION
This PR attempts to use external PSRAM for the various buffers used for generating spectrograms. If that fails; e.g., if there isn't any external memory, it falls back to using the ESP32's internal memory.

Bumps the PlatformIO library version to 1.1.0