### PR TITLE
Add missing stdint.h include to kiss_fft.h

### DIFF
--- a/src/kiss_fft.h
+++ b/src/kiss_fft.h
@@ -1,6 +1,7 @@
 #ifndef KISS_FFT_H
 #define KISS_FFT_H
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>


### PR DESCRIPTION
ESP-IDF 6.0 ships GCC 15 and switches the default C library from Newlib to Picolibc. With Picolibc, `int16_t` is no longer pulled in transitively through other headers.

This adds `#include <stdint.h>` to `kiss_fft.h` which uses `int16_t` via the `kiss_fft_scalar` typedef but was missing the include. All other headers in the library already include `<stdint.h>`.